### PR TITLE
Fix dictionary values iterator

### DIFF
--- a/pg_simple/pg_simple.py
+++ b/pg_simple/pg_simple.py
@@ -122,7 +122,8 @@ class PgSimple(object):
         cols, vals = self._format_insert(data)
         sql = 'INSERT INTO %s (%s) VALUES(%s)' % (table, cols, vals)
         sql += self._returning(returning)
-        cur = self.execute(sql, data.values())
+        values = list(data.values())
+        cur = self.execute(sql, values)
         return cur.fetchone() if returning else cur.rowcount
 
     def update(self, table, data, where=None, returning=None):
@@ -131,7 +132,8 @@ class PgSimple(object):
 
         sql = 'UPDATE %s SET %s' % (table, query)
         sql += self._where(where) + self._returning(returning)
-        cur = self.execute(sql, data.values() + where[1] if where and len(where) > 1 else data.values())
+        values = list(data.values())
+        cur = self.execute(sql, values + where[1] if where and len(where) > 1 else values)
         return cur.fetchall() if returning else cur.rowcount
 
     def delete(self, table, where=None, returning=None):


### PR DESCRIPTION
On Python 2 `dict.values()` returns a list but Python 3 returns an iterator. So I made a little change converting the iterator into a list.