### PR TITLE
Corrigi importação que causa erro ao instalar dependência

### DIFF
--- a/pg_simple/__init__.py
+++ b/pg_simple/__init__.py
@@ -2,6 +2,3 @@
 __author__ = 'Masroor Ehsan'
 
 VERSION = '0.2.3'
-
-from .pool import config_pool, get_pool, SimpleConnectionPool, ThreadedConnectionPool
-from .pg_simple import PgSimple

--- a/pg_simple/pg_simple.py
+++ b/pg_simple/pg_simple.py
@@ -9,7 +9,7 @@ import os
 
 from psycopg2.extras import RealDictCursor, NamedTupleCursor
 
-from pg_simple import pool
+from . import pool
 
 class PgSimple(object):
     _connection = None

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+psycopg2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,0 @@
-psycopg2


### PR DESCRIPTION
Mudanças feitas:
- Aplica PEP8
- Remove do `__init__` importação que causa erro ao instalar dependência.